### PR TITLE
Add RabbitVCS support

### DIFF
--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/CLIContextMenus.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/CLIContextMenus.cs
@@ -7,7 +7,6 @@ using UnityEngine;
 
 namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 {
-#if UNITY_EDITOR_WIN || UNITY_EDITOR_LINUX
 	//
 	internal class CLIContextMenus : SVNContextMenusBase
 	{
@@ -188,5 +187,4 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			CLIContextWindow.Show($"switch\n\"{url}\"\n\"{localPath}\"", false);
 		}
 	}
-#endif
 }

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
@@ -206,13 +206,22 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			return;
 		}
 
-		private string[] possibleVcsErrorString = new[]{
+		private string[] possibleRvcsErrorString = new[]{
 			"Exception: ",
 			"Error: "
 		};
+
+		/// <summary>
+		///	Gtk most of the time dumps warning and possibly non-error messages to stderr, thus making
+		/// current implementation of error reporting reports those warnings even thought the app
+		/// is completing it's task just fine.
+		///
+		/// But luckily RabbitVCS have python backend, any exception should show up in stderr as
+		/// Python-style error that can be filtered.
+		/// </summary>
 		private bool MayHaveRabbitVCSError(string src){
 			if(string.IsNullOrWhiteSpace(src)) return false;
-			foreach(string str in possibleVcsErrorString){
+			foreach(string str in possibleRvcsErrorString){
 				if(src.IndexOf(str, StringComparison.OrdinalIgnoreCase) >= 0) return true;
 			}
 			return false;

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
@@ -3,16 +3,19 @@
 using DevLocker.VersionControl.WiseSVN.Shell;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 using UnityEngine;
 
 namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 {
-#if UNITY_EDITOR_WIN || UNITY_EDITOR_LINUX
-	//
-	internal class CLIContextMenus : SVNContextMenusBase
+#if UNITY_EDITOR_LINUX
+	// TortoiseSVN Commands: https://tortoisesvn.net/docs/release/TortoiseSVN_en/tsvn-automation.html
+	internal class RabbitSVNContextMenu : SVNContextMenusBase
 	{
-		protected override string FileArgumentsSeparator => "\n";
-		protected override bool FileArgumentsSurroundQuotes => true;
+		private const string ClientCommand = "rabbitvcs";
+
+		protected override string FileArgumentsSeparator => "*";
+		protected override bool FileArgumentsSurroundQuotes => false;
 
 		public override void CheckChanges(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
 		{
@@ -23,7 +26,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"diff \n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"changes \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void DiffChanges(string assetPath, bool wait = false)
@@ -32,7 +38,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"diff \n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"diff \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void Update(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
@@ -40,14 +49,14 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (!assetPaths.Any())
 				return;
 
-			// NOTE: @ is added at the end of path, to avoid problems when file name contains @, and SVN mistakes that as "At revision" syntax".
-			//		https://stackoverflow.com/questions/757435/how-to-escape-characters-in-subversion-managed-file-names
-
 			string pathsArg = AssetPathsToContextPaths(assetPaths, includeMeta);
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"update --depth infinity --accept postpone\n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"update \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void Commit(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
@@ -59,10 +68,11 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"commit --depth infinity -m \"\"\n{pathsArg}", false);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"commit \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
-
-
 
 		public override void Add(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
 		{
@@ -84,7 +94,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"add --depth infinity\n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"add \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void Revert(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
@@ -96,22 +109,21 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"revert --depth infinity\n{pathsArg}", false);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"revert \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
-
-
 
 		public override void ResolveAll(bool wait = false)
 		{
-			CLIContextWindow.Show($"resolve --depth infinity --accept TYPE_IN_OPTION\n", false);
+			UnityEditor.EditorUtility.DisplayDialog("Not Supported", "RabbitSVN does not support Resolve All yet.", "OK");
 		}
 
 		public override void Resolve(string assetPath, bool wait = false)
 		{
-			DiffChanges(assetPath, wait);
+			UnityEditor.EditorUtility.DisplayDialog("Not Supported", "RabbitSVN does not support Resolve yet.", "OK");
 		}
-
-
 
 		public override void GetLocks(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
 		{
@@ -122,7 +134,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"lock -m \"\"\n{pathsArg}", false);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"lock \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void ReleaseLocks(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
@@ -134,7 +149,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"unlock\n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"unlock \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void ShowLog(string assetPath, bool wait = false)
@@ -146,46 +164,58 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			CLIContextWindow.Show($"log \n{pathsArg}", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"log \"{pathsArg}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
-
-
 
 		public override void Blame(string assetPath, bool wait = false)
 		{
-			if (string.IsNullOrEmpty(assetPath))
-				return;
-
-			string pathsArg = AssetPathToContextPaths(assetPath, false);
-			if (string.IsNullOrEmpty(pathsArg))
-				return;
-
-			CLIContextWindow.Show($"blame \n{pathsArg}", true);
+			UnityEditor.EditorUtility.DisplayDialog("Not Supported", "RabbitSVN does not support Blame function yet.", "OK");
 		}
-
-
 
 		public override void Cleanup(bool wait = false)
 		{
-			CLIContextWindow.Show($"cleanup", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"cleanup \"{WiseSVNIntegration.ProjectRootNative}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
-
 
 		public override void RepoBrowser(string url, bool wait = false)
 		{
 			if (string.IsNullOrEmpty(url))
 				return;
 
-			CLIContextWindow.Show($"list\n\"{url}\"", true);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"browser \"{url}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
 		}
 
 		public override void Switch(string localPath, string url, bool wait = false)
 		{
-			if (string.IsNullOrEmpty(localPath) || string.IsNullOrEmpty(url))
+			if (string.IsNullOrEmpty(url))
 				return;
 
-			// TODO: Test?
-			CLIContextWindow.Show($"switch\n\"{url}\"\n\"{localPath}\"", false);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"switch \"{url}\"", wait);
+			if (MayHaveRabbitVCSError(result.Error)) {
+				Debug.LogError($"SVN Error: {result.Error}");
+			}
+			return;
+		}
+
+		private string[] possibleVcsErrorString = new[]{
+			"Exception: ",
+			"Error: "
+		};
+		private bool MayHaveRabbitVCSError(string src){
+			if(string.IsNullOrWhiteSpace(src)) return false;
+			foreach(string str in possibleVcsErrorString){
+				if(src.IndexOf(str, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+			}
+			return false;
 		}
 	}
 #endif

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs
@@ -9,13 +9,15 @@ using UnityEngine;
 namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 {
 #if UNITY_EDITOR_LINUX
-	// TortoiseSVN Commands: https://tortoisesvn.net/docs/release/TortoiseSVN_en/tsvn-automation.html
+	// RabbitVCS subcommand (or module by their wording) list can be accessed by executing `rabbitvcs`
+	// command in terminal, and the subcommand usage reference by `rabbitvcs <module> -h`. Source code
+	// is available at https://github.com/rabbitvcs/rabbitvcs .
 	internal class RabbitSVNContextMenu : SVNContextMenusBase
 	{
 		private const string ClientCommand = "rabbitvcs";
 
-		protected override string FileArgumentsSeparator => "*";
-		protected override bool FileArgumentsSurroundQuotes => false;
+		protected override string FileArgumentsSeparator => " ";
+		protected override bool FileArgumentsSurroundQuotes => true;
 
 		public override void CheckChanges(IEnumerable<string> assetPaths, bool includeMeta, bool wait = false)
 		{
@@ -26,7 +28,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"changes \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"changes {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -38,7 +40,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"diff \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"diff -s {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -53,7 +55,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"update \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"update {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -68,7 +70,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"commit \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"commit {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -84,7 +86,6 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 					return;
 			}
 
-			// Don't give versioned metas, as tortoiseSVN doesn't like it.
 			var metas = assetPaths
 				.Select(path => path + ".meta")
 				.Where(path => WiseSVNIntegration.GetStatus(path).Status == VCFileStatus.Unversioned)
@@ -94,7 +95,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"add \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"add {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -109,7 +110,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"revert \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"revert {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -134,7 +135,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"lock \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"lock {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -149,7 +150,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"unlock \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"unlock {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}
@@ -164,7 +165,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus.Implementation
 			if (string.IsNullOrEmpty(pathsArg))
 				return;
 
-			var result = ShellUtils.ExecuteCommand(ClientCommand, $"log \"{pathsArg}\"", wait);
+			var result = ShellUtils.ExecuteCommand(ClientCommand, $"log {pathsArg}", wait);
 			if (MayHaveRabbitVCSError(result.Error)) {
 				Debug.LogError($"SVN Error: {result.Error}");
 			}

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs.meta
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/RabbitSVNContextMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64c761f49d3d6178eb341fd999185fd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/SVNContextMenusManager.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/SVNContextMenusManager.cs
@@ -14,6 +14,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 		None,
 		TortoiseSVN,	// Good for Windows
 		SnailSVN,		// Good for MacOS
+		RabbitVCS,		// Good for Linux
 		CLI,			// Good for anything
 	}
 
@@ -103,7 +104,9 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 				case ContextMenusClient.SnailSVN:
 					errorMsg = "SnailSVN is not supported on Linux.";
 					return null;
-
+				case ContextMenusClient.RabbitVCS:
+					errorMsg = string.Empty;
+					return new RabbitSVNContextMenu();
 				case ContextMenusClient.CLI:
 					errorMsg = string.Empty;
 					return new CLIContextMenus();

--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/SVNContextMenusManager.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ContextMenus/SVNContextMenusManager.cs
@@ -64,6 +64,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 					errorMsg = "SnailSVN is not supported on windows.";
 					return null;
 
+				case ContextMenusClient.RabbitVCS:
+					errorMsg = "RabbitVCS is not supported on Windows.";
+					return null;
+
 				case ContextMenusClient.CLI:
 					errorMsg = string.Empty;
 					return new CLIContextMenus();
@@ -85,6 +89,10 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 					errorMsg = string.Empty;
 					return new SnailSVNContextMenus();
 
+				case ContextMenusClient.RabbitVCS:
+					errorMsg = "RabbitVCS is not supported on OSX.";
+					return null;
+
 				case ContextMenusClient.CLI:
 					errorMsg = string.Empty;
 					return new CLIContextMenus();
@@ -95,7 +103,7 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 
 #else
 
-			switch (client) {
+            switch (client) {
 
 				case ContextMenusClient.TortoiseSVN:
 					errorMsg = "TortoiseSVN is not supported on Linux";
@@ -104,9 +112,11 @@ namespace DevLocker.VersionControl.WiseSVN.ContextMenus
 				case ContextMenusClient.SnailSVN:
 					errorMsg = "SnailSVN is not supported on Linux.";
 					return null;
+
 				case ContextMenusClient.RabbitVCS:
 					errorMsg = string.Empty;
 					return new RabbitSVNContextMenu();
+
 				case ContextMenusClient.CLI:
 					errorMsg = string.Empty;
 					return new CLIContextMenus();


### PR DESCRIPTION
I've implemented the support for issue #7 that I've opened. I've tested only functionalities that I usually use e.g Commit, Update, Repo-browser and they are working as I expected, And the rest of function should also working fine too. Theree is still some leftover from the TortoiseSVN's.

However, I'm worrying that RabbitVCS executes these commands in context of other VCS program in case of the project uses multiple VCS at once, this because RabbitVCS auto-detects if the project is using SVN, Git and Hg. But since this plugin disables it's SVN integration when it doesn't detect one, it should be fine, right?

And also, why is there still this line in `CLIContextMenus.cs`?
```csharp
#ifdef UNITY_EDITOR_WIN
```
Shouldn't CLI good for all platform? The changes I made is adapting the current code by adding `|| UNITY_EDITOR_LINUX`, though.