### PR TITLE
Ensure english shell output on Linux/MacOS

### DIFF
--- a/Assets/DevLocker/VersionControl/WiseSVN/Editor/ShellUtils.cs
+++ b/Assets/DevLocker/VersionControl/WiseSVN/Editor/ShellUtils.cs
@@ -146,6 +146,8 @@ namespace DevLocker.VersionControl.WiseSVN.Shell
 			processStartInfo.WindowStyle = ProcessWindowStyle.Hidden;
 			processStartInfo.UseShellExecute = false;
 			processStartInfo.WorkingDirectory = shellArgs.WorkingDirectory;
+			processStartInfo.EnvironmentVariables["LANG"] = "en";
+			processStartInfo.EnvironmentVariables["LC_CTYPE"] = "en_US.UTF-8";
 
 			Process process;
 			try {


### PR DESCRIPTION
Force English output when running svn commands.

"svn status" outputs "État ..." instead of "Status", resulting in an error with 'É' not found at `m_FileStatusMap[line[0]];`
